### PR TITLE
Feature/deployment name filter

### DIFF
--- a/arm-outputs/arm-outputs.ps1
+++ b/arm-outputs/arm-outputs.ps1
@@ -2,7 +2,7 @@ Write-Verbose "Entering script arm-outputs.ps1"
  
 Write-Debug "ResourceGroupName= $resourceGroupName"
 
-$lastResourceGroupDeployments = Get-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName | Sort-Object Timestamp -Descending       
+$lastResourceGroupDeployments = Get-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName | where {$_.DeploymentName -match $deploymentNameFilter -or $deploymentNameFilter -eq $null} | Sort-Object Timestamp -Descending        
 $lastResourceGroupDeployment = $lastResourceGroupDeployments | Select-Object -First 1      
 
 if ($whenLastDeploymentIsFailed -eq "latestSuccesful" ) {

--- a/arm-outputs/run-vsts.ps1
+++ b/arm-outputs/run-vsts.ps1
@@ -7,5 +7,6 @@ $resourceGroupName = Get-VstsInput -Name resourceGroupName -Require
 $prefix = Get-VstsInput -Name prefix
 $outputNames = Get-VstsInput -Name outputNames
 $whenLastDeploymentIsFailed = Get-VstsInput -Name whenLastDeploymentIsFailed
+$deploymentNameFilter = Get-VstsInput -Name deploymentNameFilter
 
 .\arm-outputs.ps1

--- a/arm-outputs/task.json
+++ b/arm-outputs/task.json
@@ -1,6 +1,6 @@
 {
     "id": "584bcff2-3353-4f11-872b-6ba01267a972",
-    "name": "ARMOutputs",
+    "name": "ARM Outputs",
     "friendlyName": "ARM Outputs",
     "description": "This task reads the output values of an ARM deployment and sets them as VSTS variable",
     "helpMarkDown": "[More Information](https://github.com/keesschollaart81/vsts-arm-outputs)",
@@ -64,23 +64,23 @@
             "helpMarkDown": "Provide a comma seperated list of ARM outputs (key/name) to process. If left empty, all outputs are processed"
         },
         {
-          "name": "whenLastDeploymentIsFailed",
-          "type": "pickList",
-          "label": "When last deployment is failed",
-          "defaultValue": "fail",
-          "required": true,
-          "helpMarkDown": "Choose the behaviour when the latest deployment is not succesful.",
-          "options": {
-            "fail": "Fail task",
-            "latestSuccesful": "Use last succesful deploment"
-          }
+            "name": "whenLastDeploymentIsFailed",
+            "type": "pickList",
+            "label": "When last deployment is failed",
+            "defaultValue": "fail",
+            "required": true,
+            "helpMarkDown": "Choose the behaviour when the latest deployment is not succesful.",
+            "options": {
+              "fail": "Fail task",
+              "latestSuccesful": "Use last succesful deploment"
+            }
         },
         {
-          "name": "deploymentNameFilter",
-          "type": "string",
-          "label": "Filter previous deployments",
-          "required": false,
-          "helpMarkDown": "Optional string to filter deployments by. This can be useful if you have concurrent deployments to the same resource group. Deployment names in Azure are the name of the json file plus date and time , so a file CreateKeyVault.json could have a deployment name of CreateKeyVault-20180025-151538-0688. In this case, if you want to filter to deployments of this file enter CreateKeyVault as the filter."
+            "name": "deploymentNameFilter",
+            "type": "string",
+            "label": "Filter previous deployments",
+            "required": false,
+            "helpMarkDown": "Optional string to filter deployments by. This can be useful if you have concurrent deployments to the same resource group. Deployment names in Azure are the name of the json file plus date and time , so a file CreateKeyVault.json could have a deployment name of CreateKeyVault-20180025-151538-0688. In this case, if you want to filter to deployments of this file enter CreateKeyVault as the filter."
         }
     ],
     "dataSourceBindings": [

--- a/arm-outputs/task.json
+++ b/arm-outputs/task.json
@@ -1,6 +1,6 @@
 {
     "id": "584bcff2-3353-4f11-872b-6ba01267a972",
-    "name": "ARM Outputs",
+    "name": "ARMOutputs",
     "friendlyName": "ARM Outputs",
     "description": "This task reads the output values of an ARM deployment and sets them as VSTS variable",
     "helpMarkDown": "[More Information](https://github.com/keesschollaart81/vsts-arm-outputs)",
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"
@@ -64,16 +64,23 @@
             "helpMarkDown": "Provide a comma seperated list of ARM outputs (key/name) to process. If left empty, all outputs are processed"
         },
         {
-            "name": "whenLastDeploymentIsFailed",
-            "type": "pickList",
-            "label": "When last deployment is failed",
-            "defaultValue": "fail",
-            "required": true,
-            "helpMarkDown": "Choose the behaviour when the latest deployment is not succesful.",
-            "options": {
-                "fail": "Fail task",
-                "latestSuccesful": "Use last succesful deploment"
-            }
+          "name": "whenLastDeploymentIsFailed",
+          "type": "pickList",
+          "label": "When last deployment is failed",
+          "defaultValue": "fail",
+          "required": true,
+          "helpMarkDown": "Choose the behaviour when the latest deployment is not succesful.",
+          "options": {
+            "fail": "Fail task",
+            "latestSuccesful": "Use last succesful deploment"
+          }
+        },
+        {
+          "name": "deploymentNameFilter",
+          "type": "string",
+          "label": "Filter previous deployments",
+          "required": false,
+          "helpMarkDown": "Optional string to filter deployments by. This can be useful if you have concurrent deployments to the same resource group. Deployment names in Azure are the name of the json file plus date and time , so a file CreateKeyVault.json could have a deployment name of CreateKeyVault-20180025-151538-0688. In this case, if you want to filter to deployments of this file enter CreateKeyVault as the filter."
         }
     ],
     "dataSourceBindings": [

--- a/arm-outputs/task.json
+++ b/arm-outputs/task.json
@@ -71,8 +71,8 @@
             "required": true,
             "helpMarkDown": "Choose the behaviour when the latest deployment is not succesful.",
             "options": {
-              "fail": "Fail task",
-              "latestSuccesful": "Use last succesful deploment"
+                "fail": "Fail task",
+                "latestSuccesful": "Use last succesful deploment"
             }
         },
         {

--- a/arm-outputs/task.json
+++ b/arm-outputs/task.json
@@ -80,7 +80,7 @@
             "type": "string",
             "label": "Filter previous deployments",
             "required": false,
-            "helpMarkDown": "Optional string to filter deployments by. This can be useful if you have concurrent deployments to the same resource group. Deployment names in Azure are the name of the json file plus date and time , so a file CreateKeyVault.json could have a deployment name of CreateKeyVault-20180025-151538-0688. In this case, if you want to filter to deployments of this file enter CreateKeyVault as the filter."
+            "helpMarkDown": "Optional string to filter deployments by. This can be useful if you have concurrent deployments to the same resource group. Deployment names in VSTS are the name of the json file plus date and time, so a file CreateKeyVault.json could have a deployment name of CreateKeyVault-20180025-151538-0688. In this case, if you want to filter to deployments of this file enter CreateKeyVault as the filter."
         }
     ],
     "dataSourceBindings": [


### PR DESCRIPTION
An optional deployment name filter for the ARM outputs. Useful to me, for when I have concurrent deployments to the same resource group, hopefully useful to others.

I realise the help markdown text is a bit lengthy, so feel welcome to rewrite it or trim it if you like :)